### PR TITLE
GCC 13 did not like having a template<> inside the class body at

### DIFF
--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -1594,9 +1594,7 @@ void LLTextEditor::cleanStringForPaste(LLWString & clean_string)
     }
 }
 
-
-template <>
-void LLTextEditor::pasteTextWithLinebreaks<LLWString>(const LLWString & clean_string)
+void LLTextEditor::pasteTextWithLinebreaksImpl(const LLWString & clean_string)
 {
     std::basic_string<llwchar>::size_type start = 0;
     std::basic_string<llwchar>::size_type pos = clean_string.find('\n',start);

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -313,10 +313,9 @@ public:
     template <typename STRINGTYPE>
     void            pasteTextWithLinebreaks(const STRINGTYPE& clean_string)
     {
-        pasteTextWithLinebreaks<LLWString>(ll_convert(clean_string));
+        pasteTextWithLinebreaksImpl(ll_convert(clean_string));
     }
-    template <>
-    void            pasteTextWithLinebreaks<LLWString>(const LLWString & clean_string);
+    void            pasteTextWithLinebreaksImpl(const LLWString & clean_string);
 
 private:
     void            onKeyStroke();


### PR DESCRIPTION
all.
Thus turn the specialization of pasteTextWithLinebreaks into a class methode pasteTextWithLinebreaksImpl.